### PR TITLE
Vim Asynchronous Lint Engine (ALE) 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,3 +100,6 @@
 [submodule "vim/bundle/vim-toml"]
 	path = vim/bundle/vim-toml
 	url = git@github.com:cespare/vim-toml.git
+[submodule "vim/bundle/ale"]
+	path = vim/bundle/ale
+	url = git@github.com:dense-analysis/ale.git


### PR DESCRIPTION
[ALE](https://github.com/dense-analysis/ale) provides lint support for most popular languages and calms sanity working with .jsx files.

After installation in vim run `:Helptags` to generate help docs for pathogen plugins. The most useful command for ALE is `ALEDetail` which expands the error message window. Details [here](https://github.com/dense-analysis/ale/pull/374).