### PR TITLE
Better JSX syntax highlighting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,9 +82,6 @@
 [submodule "vim/bundle/graphql"]
 	path = vim/bundle/graphql
 	url = git@github.com:jparise/vim-graphql.git
-[submodule "vim/bundle/jsx"]
-	path = vim/bundle/jsx
-	url = git@github.com:mxw/vim-jsx.git
 [submodule "vim/bundle/javascript"]
 	path = vim/bundle/javascript
 	url = git@github.com:pangloss/vim-javascript.git
@@ -103,3 +100,6 @@
 [submodule "vim/bundle/ale"]
 	path = vim/bundle/ale
 	url = git@github.com:dense-analysis/ale.git
+[submodule "vim-jsx-pretty"]
+	path = vim-jsx-pretty
+	url = git@github.com:MaxMEllon/vim-jsx-pretty.git


### PR DESCRIPTION
Now using [vim-jsx-pretty](https://github.com/MaxMEllon/vim-jsx-pretty) because [vim-jsx](https://github.com/mxw/vim-jsx) is deprecated. Vim-jsx-pretty seems to now be the standard, see below:

> IMPORTANT: This package is deprecated! It apparently broke following changes to the pangloss/vim-javascript JavaScript syntax package circa early 2019. As someone who has (perhaps surprisingly) never written a single line of JSX or React code except to test this package, I don't closely track breaking changes like these, hence the (lamentable) inactivity in this repo.

> Fortunately, the community seems to have settled on MaxMEllon/vim-jsx-pretty as the syntax package of choice for up-to-date JSX support. If you're not writing exclusively pre-2019 JavaScript with pre-2019 tooling, consider switching over to that package.

> Thanks for following along here, and I hope this package was useful to folks in the years since React first debuted.

> If things change and this package becomes actively maintained again, I'll be sure to update this note.

Fixes conditionals in JSX return statements 
![image](https://user-images.githubusercontent.com/14062584/96756216-c32b7680-13a1-11eb-9ccc-f14f62db21de.png)

